### PR TITLE
feat: add ClawBench browser-agent benchmark

### DIFF
--- a/data/projects/clawbench.en.md
+++ b/data/projects/clawbench.en.md
@@ -1,0 +1,38 @@
+---
+name: ClawBench
+slug: clawbench
+homepage: https://claw-bench.com
+repo: https://github.com/TIGER-AI-Lab/ClawBench
+license: Apache-2.0
+category: training-optimization
+subCategory: evaluation-benchmarks
+tags:
+  - Benchmark
+  - Evaluation
+  - AI Agent
+  - Browser Automation
+description: >-
+  ClawBench is an open-source benchmark for evaluating browser AI agents on everyday tasks across live production
+  websites, with isolated runs and five-layer execution traces.
+author: TIGER-AI-Lab
+ossDate: '2026-04-10T01:59:17.000Z'
+featured: false
+status: tracked
+---
+
+## Overview
+
+ClawBench evaluates whether browser agents can complete everyday online tasks on live production websites. Its V1 suite contains 153 tasks across 144 websites, V2 adds 130 tasks, and a 20-task Lite suite supports faster evaluation.
+
+## Key features
+
+- Runs each task in an isolated container against a real website.
+- Supports interchangeable agent harnesses for comparing model and browser-control stacks.
+- Captures video, action screenshots, HTTP traffic, browser actions, and agent messages for each run.
+- Uses request interception and task-specific evaluation schemas to score outcomes while blocking irreversible actions by default.
+
+## Use cases
+
+- Benchmark browser and computer-use agents on realistic online workflows.
+- Compare models and harnesses using reproducible task definitions and inspectable traces.
+- Diagnose failures caused by reasoning, browser control, website changes, or agent-harness behavior.

--- a/data/projects/clawbench.zh.md
+++ b/data/projects/clawbench.zh.md
@@ -1,0 +1,36 @@
+---
+name: ClawBench
+slug: clawbench
+homepage: https://claw-bench.com
+repo: https://github.com/TIGER-AI-Lab/ClawBench
+license: Apache-2.0
+category: training-optimization
+subCategory: evaluation-benchmarks
+tags:
+  - Benchmark
+  - Evaluation
+  - AI Agent
+  - Browser Automation
+description: ClawBench 是一个开源基准，用于评测浏览器 AI 智能体在真实线上网站上完成日常任务的能力，并提供隔离运行环境与五层执行轨迹。
+author: TIGER-AI-Lab
+ossDate: '2026-04-10T01:59:17.000Z'
+featured: false
+status: tracked
+---
+
+## 项目概述
+
+ClawBench 评测浏览器智能体能否在真实线上网站上完成日常任务。其 V1 套件包含来自 144 个网站的 153 项任务，V2 新增 130 项任务，并提供包含 20 项任务的 Lite 套件以支持快速评测。
+
+## 主要特性
+
+- 在隔离容器中针对真实网站运行每项任务。
+- 支持可互换的智能体 Harness，便于比较模型与浏览器控制栈。
+- 为每次运行记录视频、动作截图、HTTP 流量、浏览器操作和智能体消息。
+- 使用请求拦截与任务专属评测模式判断结果，并默认阻止不可逆操作。
+
+## 使用场景
+
+- 在真实在线工作流中评测浏览器智能体与计算机操作智能体。
+- 使用可复现的任务定义和可检查轨迹比较模型与 Harness。
+- 诊断由推理、浏览器控制、网站变化或智能体 Harness 行为导致的失败。


### PR DESCRIPTION
## Summary

- add ClawBench as a bilingual project entry
- classify it under `training-optimization / evaluation-benchmarks`
- document its live-site browser-agent tasks, interchangeable harnesses, and five-layer traces

## Why it fits

ClawBench is an active Apache-2.0 benchmark for evaluating browser AI agents on everyday tasks across live production websites. The existing `evaluation-benchmarks` category contains benchmark suites and evaluation frameworks, so this uses an established slot rather than adding a new category.

## Data checklist

- [x] Project YAML uses an existing category key.
- [x] Chinese and English descriptions are present.
- [x] GitHub repository URL is valid and not duplicated.
- [x] Score fields are omitted so the landscape's scoring pipeline can populate them.
- [x] `npm run validate` passes.
- [x] `npm run build` passes.

## Disclosure

I am a ClawBench maintainer and am submitting this project directly. This PR was prepared with AI assistance, and I reviewed the entry, links, categorization, and validation results before submission.
