### PR TITLE
feat: add Unified AI System gateway

### DIFF
--- a/data/projects/unified-ai-system.en.md
+++ b/data/projects/unified-ai-system.en.md
@@ -1,0 +1,46 @@
+---
+name: Unified AI System
+slug: unified-ai-system
+homepage: https://github.com/happy520ai/unified-ai-system
+repo: https://github.com/happy520ai/unified-ai-system
+license: Apache-2.0
+category: inference-serving
+subCategory: llm-routing-gateways
+tags:
+  - AI Gateway
+  - MCP
+  - Model Routing
+  - Agent Orchestration
+  - Self-hosted
+description: >-
+  A terminal-first, self-hosted AI gateway with model-routing foundations, governed agent workflows, an eight-tool
+  Codex MCP server, and a credential-free Docker demo.
+author: happy520ai
+ossDate: '2026-04-27T15:45:42.000Z'
+featured: false
+status: tracked
+---
+
+## Overview
+
+Unified AI System is an Apache-2.0 control plane for operating models, agents, knowledge, tools, permissions, and execution evidence through a terminal-first gateway. Its public preview starts with a deterministic local fake provider, allowing a clean clone or public container to verify the complete local path before any external provider is enabled.
+
+## Key features
+
+- Exposes terminal, HTTP API, shared SDK, and MCP interfaces without requiring a browser UI.
+- Provides an eight-tool stdio MCP server for gateway health, readiness, fake-provider chat, knowledge, workflows, and workforce status.
+- Includes explicit provider selection and model-routing foundations while keeping real provider execution opt-in.
+- Brings approval, permission, interruption, and evidence surfaces into the governed execution path.
+- Offers a one-command Docker demonstration that requires no account or API key.
+
+## Use cases
+
+- Evaluate a local AI gateway architecture before configuring paid or external providers.
+- Connect Codex or another MCP client to inspect gateway, knowledge, workflow, and workforce readiness.
+- Build a self-hosted control plane that keeps model routing and agent execution observable and accountable.
+
+## Technical highlights
+
+- JavaScript and TypeScript pnpm monorepo organized as a modular gateway service with reusable packages.
+- Apache-2.0 source, public multi-architecture container, and an official MCP Registry distribution.
+- Credential-free public-clone verification checks health, chat, examples, MCP discovery, fake-provider use, and managed process cleanup.

--- a/data/projects/unified-ai-system.en.md
+++ b/data/projects/unified-ai-system.en.md
@@ -13,8 +13,8 @@ tags:
   - Agent Orchestration
   - Self-hosted
 description: >-
-  A terminal-first, self-hosted AI gateway with model-routing foundations, governed agent workflows, an eight-tool
-  Codex MCP server, and a credential-free Docker demo.
+  A terminal-first, self-hosted AI gateway with model-routing foundations, governed agent workflows, nine MCP tools,
+  provider-free prompt enhancement, and a credential-free Docker demo.
 author: happy520ai
 ossDate: '2026-04-27T15:45:42.000Z'
 featured: false
@@ -28,7 +28,7 @@ Unified AI System is an Apache-2.0 control plane for operating models, agents, k
 ## Key features
 
 - Exposes terminal, HTTP API, shared SDK, and MCP interfaces without requiring a browser UI.
-- Provides an eight-tool stdio MCP server for gateway health, readiness, fake-provider chat, knowledge, workflows, and workforce status.
+- Provides nine stdio MCP tools for provider-free prompt enhancement, gateway health, readiness, fake-provider chat, knowledge, workflows, and workforce status.
 - Includes explicit provider selection and model-routing foundations while keeping real provider execution opt-in.
 - Brings approval, permission, interruption, and evidence surfaces into the governed execution path.
 - Offers a one-command Docker demonstration that requires no account or API key.

--- a/data/projects/unified-ai-system.zh.md
+++ b/data/projects/unified-ai-system.zh.md
@@ -12,7 +12,7 @@ tags:
   - Model Routing
   - Agent Orchestration
   - Self-hosted
-description: Unified AI System 是一个终端优先的自托管 AI 网关，提供模型路由基础、受治理的智能体工作流、包含八个工具的 Codex MCP Server，以及无需凭据的 Docker 演示。
+description: Unified AI System 是一个终端优先的自托管 AI 网关，提供模型路由基础、受治理的智能体工作流、九个 MCP 工具、无需 Provider 的自然语言增强，以及无需凭据的 Docker 演示。
 author: happy520ai
 ossDate: '2026-04-27T15:45:42.000Z'
 featured: false
@@ -26,7 +26,7 @@ Unified AI System 是一个采用 Apache-2.0 许可证的 AI 控制平面，用�
 ## 主要特性
 
 - 提供终端、HTTP API、共享 SDK 与 MCP 接口，默认不依赖浏览器 UI。
-- 提供包含八个工具的 stdio MCP Server，覆盖网关健康、就绪状态、假 Provider 对话、知识、工作流与智能体团队状态。
+- 提供九个 stdio MCP 工具，覆盖无需 Provider 的自然语言增强、网关健康、就绪状态、假 Provider 对话、知识、工作流与智能体团队状态。
 - 提供显式 Provider 选择与模型路由基础，真实 Provider 调用必须主动启用。
 - 将审批、权限、中断控制与执行证据纳入受治理的执行路径。
 - 提供无需账号或 API Key 的一条命令 Docker 演示。

--- a/data/projects/unified-ai-system.zh.md
+++ b/data/projects/unified-ai-system.zh.md
@@ -1,0 +1,44 @@
+---
+name: Unified AI System
+slug: unified-ai-system
+homepage: https://github.com/happy520ai/unified-ai-system
+repo: https://github.com/happy520ai/unified-ai-system
+license: Apache-2.0
+category: inference-serving
+subCategory: llm-routing-gateways
+tags:
+  - AI Gateway
+  - MCP
+  - Model Routing
+  - Agent Orchestration
+  - Self-hosted
+description: Unified AI System 是一个终端优先的自托管 AI 网关，提供模型路由基础、受治理的智能体工作流、包含八个工具的 Codex MCP Server，以及无需凭据的 Docker 演示。
+author: happy520ai
+ossDate: '2026-04-27T15:45:42.000Z'
+featured: false
+status: tracked
+---
+
+## 项目概述
+
+Unified AI System 是一个采用 Apache-2.0 许可证的 AI 控制平面，用于通过终端优先的网关统一组织模型、智能体、知识、工具、权限与执行证据。其公开预览默认使用确定性的本地假 Provider，让用户能够在启用任何外部模型之前，通过干净克隆或公共容器验证完整的本地调用路径。
+
+## 主要特性
+
+- 提供终端、HTTP API、共享 SDK 与 MCP 接口，默认不依赖浏览器 UI。
+- 提供包含八个工具的 stdio MCP Server，覆盖网关健康、就绪状态、假 Provider 对话、知识、工作流与智能体团队状态。
+- 提供显式 Provider 选择与模型路由基础，真实 Provider 调用必须主动启用。
+- 将审批、权限、中断控制与执行证据纳入受治理的执行路径。
+- 提供无需账号或 API Key 的一条命令 Docker 演示。
+
+## 使用场景
+
+- 在配置付费或外部模型 Provider 之前，评估本地 AI 网关架构。
+- 将 Codex 或其他 MCP 客户端连接到网关，检查知识、工作流与智能体团队的就绪状态。
+- 构建自托管控制平面，使模型路由与智能体执行保持可观察、可中断和可追责。
+
+## 技术特点
+
+- 采用 JavaScript、TypeScript 与 pnpm 的 Monorepo，以模块化网关服务和可复用 Package 组织代码。
+- 提供 Apache-2.0 源码、公开的多架构容器与官方 MCP Registry 分发条目。
+- 无凭据公开克隆验证会检查健康状态、对话、示例、MCP 工具发现、假 Provider 使用以及托管进程清理。


### PR DESCRIPTION
## Summary

- add Unified AI System as a bilingual project entry
- classify it under `inference-serving / llm-routing-gateways`
- document its terminal-first gateway, nine-tool MCP server, provider-free prompt enhancement, governed execution surfaces, and credential-free Docker verification

## Why it fits

Unified AI System is an active Apache-2.0, self-hosted AI gateway with explicit provider selection, model-routing foundations, an active/latest Official MCP Registry distribution, and MCP-facing prompt enhancement, health, readiness, knowledge, workflow, and workforce tools. The existing `llm-routing-gateways` category is the direct fit and requires no taxonomy changes.

## Data checklist

- [x] Project metadata uses an existing category key.
- [x] Chinese and English descriptions are present.
- [x] GitHub repository URL is valid and not duplicated.
- [x] Score fields are omitted so the landscape scoring pipeline can populate them.
- [x] Original `npm run validate` passed.
- [x] Original `npm run build` passed.

## Validation note

The original validation and full build ran in a same-commit LF checkout matching Linux CI: 680 projects validated and 1,409 static pages built, including both Unified AI System routes. This refresh changes only the two bilingual description documents from eight to nine tools and adds the current provider-free prompt-enhancement capability; repository CI remains the authoritative check for the new head.

Current release: https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.0

Official Registry: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.0

## Disclosure

I maintain Unified AI System and am submitting the project directly. This PR was prepared with AI assistance, and I reviewed the entry, links, categorization, and validation results before submission.